### PR TITLE
PHP open_basedir restrictions errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ RUN chown -R http:http /usr/share/webapps/owncloud/
 # expose some important directories as volumes
 #VOLUME ["/usr/share/webapps/owncloud/data"]
 #VOLUME ["/etc/webapps/owncloud/config"]
-#VOLUME [“/usr/share/webapps/owncloud/apps”]
+#VOLUME ["/usr/share/webapps/owncloud/apps"]
 
 # place your ssl cert files in here. name them server.key and server.crt
 #VOLUME ["/https"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,9 @@ RUN sed -i 's,Options Indexes FollowSymLinks,Options -Indexes +FollowSymLinks,g'
 RUN sed -i '$a Include conf/extra/owncloud.conf' /etc/httpd/conf/httpd.conf
 RUN chown -R http:http /usr/share/webapps/owncloud/
 
+# configure PHP open_basedir
+RUN sed -i 's,^open_basedir.*$,\0:/usr/share/webapps/owncloud/:/usr/share/webapps/owncloud/config/:/etc/webapps/owncloud/config/,g' /etc/php/php.ini
+
 # expose some important directories as volumes
 #VOLUME ["/usr/share/webapps/owncloud/data"]
 #VOLUME ["/etc/webapps/owncloud/config"]


### PR DESCRIPTION
Hello! I have faced multiple errors in _/usr/share/webapps/owncloud/data/owncloud.log_ with messages like:  

``` json
{
"reqId":"9297ba572f40001a269e307d90d674ff",
"remoteAddr":"",
"app":"PHP",
"message":"file_exists(): open_basedir restriction in effect. File(\/usr\/share\/webapps\/owncloud\/config\/config.php) is not within the allowed path(s): (\/srv\/http\/:\/home\/:\/tmp\/:\/usr\/share\/pear\/:\/usr\/share\/webapps\/:\/usr\/share\/webapps\/config\/) at \/usr\/share\/webapps\/owncloud\/lib\/private\/config.php#171",
"level":3,
"time":"2015-06-01T07:38:23+00:00"
}
```

To **fix** them I added ownCloud PHP scripts paths to PHP **open_basedir** in _/etc/php/php.ini_. And errors gone)
