### PR TITLE
Added cron support.  Fixed issues with 'occ' execution and config folder permissions.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,11 +77,12 @@ RUN chown -R http:http /usr/share/webapps/owncloud/
 # place your ssl cert files in here. name them server.key and server.crt
 #VOLUME ["/https"]
 
-# cron (Issue #42)
+# Enable cron (Issue #42)
 RUN pacman -S --noconfirm --needed cronie
 RUN systemctl enable cronie.service
 ADD configs/cron.conf /etc/oc-cron.conf
 RUN crontab /etc/oc-cron.conf
+RUN systemctl start cronie.service; exit 0 # force success due to issue with cronie start https://goo.gl/DcGGb
 
 # start servers
 CMD ["/root/startServers.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,9 @@ ENV TARGET_SUBDIR owncloud
 # remove info.php
 RUN rm /srv/http/info.php
 
+# to to run cron as HTTP
+RUN pacman -S --noconfirm --needed sudo
+
 # to mount SAMBA shares: 
 RUN pacman -S --noconfirm --needed smbclient
 
@@ -28,7 +31,7 @@ RUN pacman -S --noconfirm --needed libreoffice-fresh
 # Install owncloud
 RUN pacman -S --noconfirm --needed owncloud
 # add our custom config.php
-ADD config.php /usr/share/webapps/owncloud/config/config.php
+ADD configs/oc-config.php /usr/share/webapps/owncloud/config/config.php
 
 # fixup the permissions (because appairently the package maintainer can't get it right)
 ADD fixPerms.sh /root/fixPerms.sh
@@ -53,6 +56,10 @@ RUN sed -i "s,php_value upload_max_filesize 513M,php_value upload_max_filesize $
 RUN sed -i "s,php_value post_max_size 513M,php_value post_max_size ${MAX_UPLOAD_SIZE},g" /usr/share/webapps/owncloud/.htaccess
 RUN sed -i 's,<IfModule mod_php5.c>,<IfModule mod_php5.c>\nphp_value output_buffering Off,g' /usr/share/webapps/owncloud/.htaccess
 
+# set up PHP for owncloud
+RUN sed -i 's/open_basedir = \/srv\/http\/:\/home\/:\/tmp\/:\/usr\/share\/pear\/:\/usr\/share\/webapps\//open_basedir = \/srv\/http\/:\/home\/:\/tmp\/:\/usr\/share\/pear\/:\/usr\/share\/webapps\/:\/etc\/webapps\//g' /etc/php/php.ini  # fixes issue with config not editable and occ errors (Issue #44)
+RUN sed -i 's/;extension=posix.so/extension=posix.so/g' /etc/php/php.ini  # needed for cron / occ (Issue #42)
+
 # setup Apache for owncloud
 RUN cp /etc/webapps/owncloud/apache.example.conf /etc/httpd/conf/extra/owncloud.conf
 RUN sed -i '/<VirtualHost/,/<\/VirtualHost>/d' /etc/httpd/conf/extra/owncloud.conf
@@ -69,6 +76,12 @@ RUN chown -R http:http /usr/share/webapps/owncloud/
 
 # place your ssl cert files in here. name them server.key and server.crt
 #VOLUME ["/https"]
+
+# cron (Issue #42)
+RUN pacman -S --noconfirm --needed cronie
+RUN systemctl enable cronie.service
+ADD configs/cron.conf /etc/oc-cron.conf
+RUN crontab /etc/oc-cron.conf
 
 # start servers
 CMD ["/root/startServers.sh"]

--- a/config.php
+++ b/config.php
@@ -1,4 +1,0 @@
-<?php
-$CONFIG = array (
-  'memcache.local' => '\\OC\\Memcache\\XCache',
-);

--- a/configs/cron.conf
+++ b/configs/cron.conf
@@ -1,0 +1,2 @@
+# m   h  dom mon dow   command
+*/15  *  *   *   *     sudo -u http php -f /usr/share/webapps/owncloud/cron.php >> /usr/share/webapps/owncloud/cron.log 2>&1

--- a/configs/oc-config.php
+++ b/configs/oc-config.php
@@ -1,0 +1,4 @@
+<?php
+$CONFIG = array (
+  'memcache.local' => '\\OC\\Memcache\\XCache',
+);


### PR DESCRIPTION
I pulled some of the methodology from @jchaney container in order to get the cron working.  The cron.conf can be rolled into the docker file if necessary.

The occ and config permissions issue is resolved by adding the symbolic link destination to the open_basedir property in the php.ini.

It needs more testing, but this is how I'm able to get my docker arch based owncloud image working with updating News and a working occ.
