### PR TITLE
turn off HTTP TRACE vulnerability

### DIFF
--- a/configs/apache.conf
+++ b/configs/apache.conf
@@ -23,3 +23,4 @@ Alias /${TARGET_SUBDIR} "/usr/share/webapps/owncloud/"
 
 </Directory>
 
+TraceEnable Off


### PR DESCRIPTION
There is a vulnerability in apache when allowing HTTP TRACE requests. It is only used for debugging, so we may as well turn it off. ;)

http://www.kb.cert.org/vuls/id/867593
